### PR TITLE
Improvements on index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -5,7 +5,7 @@ $app = new \Slim\App($container);
 
 $routes = scandir(__DIR__ . '/../app/Routes/');
 foreach ($routes as $route) {
-    if (strpos($route, '.php')) {
+    if (is_file(__DIR__ . '/../app/Routes/' . $route) && pathinfo(__DIR__ . '/../app/Routes/' . $route, PATHINFO_EXTENSION)['extension'] === 'php')) {
         require __DIR__ . '/../app/Routes/' . $route;
     }
 }


### PR DESCRIPTION
Using `strpos` you are not sure the file is with `php` extension.
Right now also `example.php.html` is triggered.